### PR TITLE
Bump version to 6.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM commerceexperts/docker-elasticsearch:6.6.0
+FROM commerceexperts/docker-elasticsearch:6.6.1
 LABEL maintainer="gabriel.bauer@commerce-experts.com"
 LABEL author="pjpires@gmail.com, gabriel.bauer@commerce-experts.com"
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 Ready to use, lean Elasticsearch Docker image ready for using within a Kubernetes cluster.
 
-[Docker Repository on DockerHub](https://cloud.docker.com/repository/registry-1.docker.io/commerceexperts/docker-elasticsearch-kubernetes)
+[Docker Repository on DockerHub](https://hub.docker.com/r/commerceexperts/docker-elasticsearch-kubernetes)
 
 ## Current software
 
 * Alpine Linux 3.9
 * IcedTea JRE 8u191
-* Elasticsearch 6.6.0
+* Elasticsearch 6.6.1
 
 **Note:** `x-pack-ml` module is forcibly disabled as it's not supported on Alpine Linux.
 


### PR DESCRIPTION
Depends on https://github.com/CommerceExperts/docker-elasticsearch/pull/1